### PR TITLE
support LangStr in IGraph removals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelong
+## 0.1.3
+- Dependency reform. Upgraded jena to v. 4.3.1
+
+## 0.1.1
+- Added support for round-tripping blank nodes

--- a/project.clj
+++ b/project.clj
@@ -1,35 +1,32 @@
 
-(defproject ont-app/igraph-jena "0.1.3-SNAPSHOT"
+(defproject ont-app/igraph-jena "0.1.3"
   :description "Library to port the Apache Jena APIs to the ont-app/iGraph protocol"
   :url "https://github.com/ont-app/igraph-jena"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [;; deps ambiguities
+                 ;; <none>
                  ;; clojure
                  [org.clojure/clojure "1.10.3"]
                  [org.clojure/spec.alpha "0.3.218"]
                  ;; 3rd party libs
-                 [org.apache.jena/jena-core "4.3.1" ;;"3.17.0"
+                 [org.apache.jena/jena-core "4.3.1" 
                   :exclusions [com.fasterxml.jackson.core/jackson-core
                                ]
                   ]
-                 [org.apache.jena/jena-arq  "4.3.1" ;"3.17.0"
+                 [org.apache.jena/jena-arq  "4.3.1" 
                   :exclusions [com.fasterxml.jackson.core/jackson-core
                                ]
                   ]
-                 [org.apache.jena/jena-base  "4.3.1" ;"3.17.0"
+                 [org.apache.jena/jena-base  "4.3.1"
                   :exclusions [com.fasterxml.jackson.core/jackson-core
                                ]
                   ]
-                 [org.apache.jena/jena-iri   "4.3.1" ;"3.17.0"
+                 [org.apache.jena/jena-iri   "4.3.1"
                   :exclusions [com.fasterxml.jackson.core/jackson-core
                                ]
                   ]
-                 #_[ont-app/graph-log "0.1.5-SNAPSHOT"
-                  :exclusions [org.clojure/clojurescript
-                               com.google.errorprone/error_prone_annotations
-                               ]]
-                 [ont-app/rdf "0.1.4-SNAPSHOT"
+                 [ont-app/rdf "0.1.4"
                   :exclusions [org.clojure/clojurescript
                                com.google.errorprone/error_prone_annotations
                                ]]

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 
-(defproject ont-app/igraph-jena "0.1.2-SNAPSHOT"
+(defproject ont-app/igraph-jena "0.1.2"
   :description "Library to port the Apache Jena APIs to the ont-app/iGraph protocol"
   :url "https://github.com/ont-app/igraph-jena"
   :license {:name "Eclipse Public License"

--- a/src/ont_app/igraph_jena/core.clj
+++ b/src/ont_app/igraph_jena/core.clj
@@ -11,6 +11,8 @@
    [ont-app.graph-log.core :as glog]
    )
   (:import
+   [ont_app.vocabulary.lstr
+    LangStr]
    [org.apache.jena.rdf.model.impl
     LiteralImpl]
    [org.apache.jena.riot
@@ -274,12 +276,15 @@
     (voc/uri-for s))
    (ResourceFactory/createProperty
     (voc/uri-for p))
-   (if (keyword? o)
-     (ResourceFactory/createResource
-      (voc/uri-for o))
-     ;; else it's not a uri
-     (ResourceFactory/createTypedLiteral
-      o)))
+   (cond
+     (keyword? o)
+     (ResourceFactory/createResource (voc/uri-for o))
+
+     (instance? LangStr o)
+     (ResourceFactory/createLangLiteral (str o) (.lang o))
+
+     :else
+     (ResourceFactory/createTypedLiteral o)))
   g)
 
 (defmethod remove-from-graph [JenaGraph :underspecified-triple]


### PR DESCRIPTION
I went looking for removal functionality in IGraph and noticed that—while it does use your own Vocabulary lib—removal of triples containing LangStrings wasn't supported. This is just a quick fix to support that scenario.